### PR TITLE
Do not use VOLUME

### DIFF
--- a/alpine-mariadb/Dockerfile
+++ b/alpine-mariadb/Dockerfile
@@ -12,7 +12,5 @@ chmod -R 755 /scripts
 EXPOSE 3306
 # WORKDIR /app
 
-VOLUME ["/var/lib/mysql"]
-
 ENTRYPOINT ["/scripts/run.sh"]
 


### PR DESCRIPTION
If you specify a volume in Dockerfile, it would be impossible to remove/override it using command line options.
Moreover, it would leave dangling volumes for inexperienced users and users of docker-compose.
In docker-compose, you wouldn't be able to specify mounted volume.
Please let the user specify the volume location.
